### PR TITLE
add 202 http response code support

### DIFF
--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -172,6 +172,7 @@ HttpClient.prototype.send = function(options) {
                     switch (status) {
                         case 200:
                         case 201:
+                        case 202:
                         case 204:
                             deferred.resolve(response);
                             break;


### PR DESCRIPTION
bluemix object store returns a 202 response code (which means "Accepted" by general convention). this PR adds support for this response code.

closes #5 